### PR TITLE
Optionally configure instance type on deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,4 +58,8 @@ bash deploy_instance_stack.sh [-i INSTANCE_TYPE] <ENVIRONMENT> [<USER>]
 Locate the DNS of the load balancer and navigate to port 8888 to see the notebook server. From the browser, open
 a new Terminal to run your git commands.
 
-Use the `delete-stack` command or the AWS UI to destroy the stack when you're done.
+Use the `delete-stack` command or the AWS UI to destroy the stack when you're done:
+
+```
+aws cloudformation delete-stack --role-arn <ROLE ARN> --profile <AWS PROFILE> --stack-name <INSTANCE_STACK_NAME_PREFIX>-<USER>
+```

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Prior to a working session, bring up the CloudFormation stack of instance resour
 an Application Load Balancer, and a service in the ECS cluster that runs the latest `notebook-server` Docker image.
 
 ```
-bash deploy_instance_stack.sh <ENVIRONMENT> [<USER>]
+bash deploy_instance_stack.sh [-i INSTANCE_TYPE] <ENVIRONMENT> [<USER>]
 ```
 
 Locate the DNS of the load balancer and navigate to port 8888 to see the notebook server. From the browser, open

--- a/deploy_instance_stack.sh
+++ b/deploy_instance_stack.sh
@@ -3,16 +3,21 @@ set -e
 set -u
 
 show_usage_and_exit() {
-  echo "Usage: `basename $0` ENVIRONMENT [USER]"
+  echo "Usage: `basename $0` [-i INSTANCE_TYPE] ENVIRONMENT [USER]"
   echo "ENVIRONMENT should be 'development' or 'production' and correspond to the AWS account to which you want to deploy."
   echo "USER is the suffix used in naming stack resources and defaults to $USER"
   exit ${1-0}
 }
 
-while getopts ":h" opt; do
+instance_type=""
+
+while getopts "hi:" opt; do
   case $opt in
     h)
       show_usage_and_exit
+      ;;
+    i)
+      instance_type="ParameterKey=InstanceType,ParameterValue=${OPTARG}"
       ;;
     \?)
       echo "Invalid option: -$OPTARG" >&2
@@ -53,4 +58,4 @@ aws --profile $AWS_PROFILE cloudformation create-stack --region us-east-1 --disa
     --parameters ParameterKey=Prefix,ParameterValue="$user" ParameterKey=PersistentStackName,ParameterValue="$PERSISTENT_STACK_NAME" \
     ParameterKey=Image,ParameterValue="$IMAGE_LOCATION" ParameterKey=BaseStackName,ParameterValue="$BASE_STACK_NAME" \
     ParameterKey=GithubToken,ParameterValue="$GITHUB_TOKEN" ParameterKey=DBPassword,ParameterValue="$DB_PASSWORD" \
-    ParameterKey=NotebookPassword,ParameterValue="$NOTEBOOK_PASSWORD"
+    ParameterKey=NotebookPassword,ParameterValue="$NOTEBOOK_PASSWORD" $instance_type

--- a/deploy_instance_stack.sh
+++ b/deploy_instance_stack.sh
@@ -11,17 +11,13 @@ show_usage_and_exit() {
 
 instance_type=""
 
-while getopts "hi:" opt; do
+while getopts ":hi:" opt; do
   case $opt in
     h)
       show_usage_and_exit
       ;;
     i)
       instance_type="ParameterKey=InstanceType,ParameterValue=${OPTARG}"
-      ;;
-    \?)
-      echo "Invalid option: -$OPTARG" >&2
-      exit 1
       ;;
   esac
 done


### PR DESCRIPTION
Adds an option `-i` to the deploy script for instance stack resources to specify the desired EC2 instance type. If unset, the instance type will default to that specified in the CloudFormation template.